### PR TITLE
fix manpath

### DIFF
--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -37,5 +37,5 @@ if type 'fd' > /dev/null; then
 fi
 
 if [[ -d ~/.fzf/man ]]; then
-  export MANPATH="$MANPATH:/~.fzf/man"
+  export MANPATH="$MANPATH:~/.fzf/man"
 fi


### PR DESCRIPTION
Correct typo in the added fzf manpath directory

<!--- Provide a general summary of your changes in the Title above -->

just transpose from /~ to ~/

<!--- Describe your changes in detail -->

# Checklist:

- [ x ] All new and existing tests pass.
- [ x ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [ x ] Scripts are marked executable
- [ x ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ x ] I have confirmed that the link(s) in my PR are valid.
- [ x ] I have read the **CONTRIBUTING** document.

# License Acceptance

- [ x ] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
