### PR TITLE
fix typo in FZF_DEFAULT_OPTS env var

### DIFF
--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -28,7 +28,7 @@ fi
 
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
 
-export FZF_DEFAULT_OPS='--extended'
+export FZF_DEFAULT_OPTS='--extended'
 export FZF_CTRL_T_COMMAND="${FZF_DEFAULT_COMMAND}"
 
 # If fd command is installed, use it instead of find


### PR DESCRIPTION
fzf looks for FZF_DEFAULT_OPTS  not ,,,_OPS

<!--- Provide a general summary of your changes in the Title above -->

another 1 character change man_shrugging:
(probably best to squash this with that last PR I just sent) :

<!--- Describe your changes in detail -->

- [x ] All new and existing tests pass.
- [x ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [x ] Scripts are marked executable
- [ x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ x] I have confirmed that the link(s) in my PR are valid.
- [ x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [ x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
