### PR TITLE
Add more fzf helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Issue Count](https://codeclimate.com/github/unixorn/fzf-zsh-plugin/badges/issue_count.svg)](https://codeclimate.com/github/unixorn/fzf-zsh-plugin)
 [![GitHub stars](https://img.shields.io/github/stars/unixorn/fzf-zsh-plugin.svg)](https://github.com/unixorn/fzf-zsh-plugin/stargazers)
 
-ZSH plugin to enable using `fzf` to search command history and for files.
+ZSH plugin to enable using [fzf](https://github.com/junegunn/fzf) to search command history and for files.
 
 This will automagically install `fzf` into your home directory if it isn't already there, and bind `^R` to an `fzf`-powered search of your command history.
 

--- a/bin/fzf-find-edit
+++ b/bin/fzf-find-edit
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Original source: https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+# Functions from https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html
+if has bat; then
+  fzf-find-edit() {
+    local file=$(
+      fzf --query="$1" --no-multi --select-1 --exit-0 \
+        --preview 'bat --color=always --line-range :500 {}'
+      )
+    if [[ -n "$file" ]]; then
+      $EDITOR "$file"
+    fi
+  }
+else
+  # No bat installed, so use head
+  fzf-find-edit() {
+    local file=$(
+      fzf --query="$1" --no-multi --select-1 --exit-0 \
+        --preview 'head -100 {}'
+      )
+    if [[ -n "$file" ]]; then
+      $EDITOR "$file"
+    fi
+  }
+fi
+
+# shellcheck disable=SC2068
+fzf-find-edit $@

--- a/bin/fzf-grep-edit
+++ b/bin/fzf-grep-edit
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Original source: https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+if ! has rg; then
+  fail "Can't find rg - install ripgrep and try again."
+fi
+
+if has bat; then
+  fzf-grep-edit(){
+    if [[ $# == 0 ]]; then
+      echo 'Error: search term was not provided.'
+      return
+    fi
+    local match=$(
+      rg --color=never --line-number "$1" |
+        fzf --no-multi --delimiter : \
+          --preview "bat --color=always --line-range {2}: {1}"
+      )
+    local file=$(echo "$match" | cut -d':' -f1)
+    if [[ -n $file ]]; then
+      $EDITOR "$file" +$(echo "$match" | cut -d':' -f2)
+    fi
+  }
+else
+  fzf-grep-edit(){
+    if [[ $# == 0 ]]; then
+      echo 'Error: search term was not provided.'
+      return
+    fi
+    local match=$(
+      rg --color=never --line-number "$1" |
+        fzf --no-multi --delimiter : \
+          --preview "head -100 {2}: {1}"
+      )
+    local file=$(echo "$match" | cut -d':' -f1)
+    if [[ -n $file ]]; then
+      $EDITOR "$file" +$(echo "$match" | cut -d':' -f2)
+    fi
+  }
+fi
+# shellcheck disable=SC2068
+fzf-grep-edit $@

--- a/bin/fzf-kill
+++ b/bin/fzf-kill
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Original source: https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+fzf-kill() {
+  local pid_col
+  local pids
+
+  if [[ $(uname) = Linux ]]; then
+    pid_col=2
+    pids=$(
+      ps -f -u "$USER" | sed 1d | fzf --multi | tr -s "[:blank:]" | cut -d' ' -f"$pid_col"
+    )
+  elif [[ $(uname) = Darwin ]]; then
+    pid_col=3;
+    pids=$(
+      ps -f -u "$USER" | sed 1d | fzf --multi | tr -s "[:blank:]" | cut -d' ' -f"$pid_col"
+    )
+  elif [[ $(uname) = FreeBSD ]]; then
+    pid_col=2
+    pids=$(
+      ps -axu -U "$USER" | sed 1d | fzf --multi | tr -s "[:blank:]" | cut -d' ' -f"$pid_col"
+    )
+  else
+    echo 'Error: unknown platform'
+    return
+  fi
+
+  if [[ -n "$pids" ]]; then
+    echo "$pids" | xargs kill -9 "$@"
+  fi
+}
+
+# shellcheck disable=SC2068
+fzf-kill $@

--- a/bin/git-fzf-add
+++ b/bin/git-fzf-add
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Original source: https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+if has bat; then
+  git-fzf-add() {
+    local selections=$(
+      git status --porcelain | \
+      fzf --ansi \
+        --preview 'if (git ls-files --error-unmatch {2} &>/dev/null); then
+                    git diff --color=always {2}
+                  else
+                      bat --color=always --line-range :500 {2}
+                  fi'
+      )
+    if [[ -n $selections ]]; then
+        git add --verbose $(echo "$selections" | cut -c 4- | tr '\n' ' ')
+    fi
+  }
+else
+  # Use head since bat is missing
+  git-fzf-add() {
+    local selections=$(
+      git status --porcelain | \
+      fzf --ansi \
+        --preview 'if (git ls-files --error-unmatch {2} &>/dev/null); then
+                    git diff --color=always {2}
+                  else
+                      head -100 {2}
+                  fi'
+      )
+    if [[ -n $selections ]]; then
+        git add --verbose $(echo "$selections" | cut -c 4- | tr '\n' ' ')
+    fi
+  }
+fi
+# shellcheck disable=SC2068
+git-fzf-add $@

--- a/bin/git-fzf-log-browser
+++ b/bin/git-fzf-log-browser
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Original source: https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+git-fzf-log-browser() {
+  selections=$(
+    git log --graph --format="%C(yellow)%h%C(red)%d%C(reset) - %C(bold green)(%ar)%C(reset) %s %C(blue)<%an>%C(reset)" --color=always "$@" |
+      fzf --ansi --no-sort --no-height \
+          --preview "echo {} | grep -o '[a-f0-9]\{7\}' | head -1 |
+                      xargs -I@ sh -c 'git show --color=always @'"
+    )
+  if [[ -n "$selections" ]]; then
+    commits=$(echo "$selections" | sed 's/^[* |]*//' | cut -d' ' -f1 | tr '\n' ' ')
+    # shellcheck disable=SC2086
+    git show $commits
+  fi
+}
+
+# shellcheck disable=SC2068
+git-fzf-log-browser $@

--- a/bin/git-fzf-pickaxe-browser
+++ b/bin/git-fzf-pickaxe-browser
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Original source: https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+git-fzf-log-pickaxe() {
+  if [[ $# == 0 ]]; then
+    echo 'Error: search term was not provided.'
+    return
+  fi
+  selections=$(
+    git log --oneline --color=always -S "$@" |
+      fzf --ansi --no-sort --no-height \
+          --preview "git show --color=always {1}"
+    )
+  if [[ -n $selections ]]; then
+    commits=$(echo "$selections" | cut -d' ' -f1 | tr '\n' ' ')
+    git show $commits
+  fi
+ }
+
+# shellcheck disable=SC2068
+git-fzf-log-pickaxe $@

--- a/bin/git-fzf-reflog-browser
+++ b/bin/git-fzf-reflog-browser
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Original source: https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+git-fzf-reflog-browser() {
+  selection=$(
+    git reflog --color=always "$@" |
+      fzf --no-multi --ansi --no-sort --no-height \
+          --preview "git show --color=always {1}"
+    )
+  if [[ -n "$selection" ]]; then
+    git show $(echo $selection | cut -d' ' -f1)
+  fi
+}
+# shellcheck disable=SC2068
+git-fzf-reflog-browser $@

--- a/bin/git-fzf-reflog-browser
+++ b/bin/git-fzf-reflog-browser
@@ -19,7 +19,8 @@ git-fzf-reflog-browser() {
           --preview "git show --color=always {1}"
     )
   if [[ -n "$selection" ]]; then
-    git show $(echo $selection | cut -d' ' -f1)
+    # shellcheck disable=SC2086
+    git show "$(echo $selection | cut -d' ' -f1)"
   fi
 }
 # shellcheck disable=SC2068

--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -58,6 +58,22 @@ if has 'fd'; then
 
 fi
 
+if has tree; then
+  fzf-change-directory() {
+    local directory=$(
+      fd --type d | \
+      fzf --query="$1" --no-multi --select-1 --exit-0 \
+        --preview 'tree -C {} | head -100'
+      )
+    if [[ -n "$directory" ]]; then
+      cd "$directory"
+    fi
+  }
+  alias fcd=fzf-change-directory
+fi
+
+alias fkill='fzf-kill'
+
 if [[ -d ~/.fzf/man ]]; then
   export MANPATH="$MANPATH:~/.fzf/man"
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Add `git-fzf-add`, `git-fzf-log-browser`, `git-fzf-pickaxe-browser`, and `git-fzf-reflog-browser` scripts that all use `fzf` to interact with `git`.
- Add `fzf-find-edit` script - uses `fzf` to select a file and calls `$EDITOR` on it
- Add `fzf-kill` - uses `fzf` to pick a process to kill

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
