### PR TITLE
Add missing function

### DIFF
--- a/bin/fzf-find-edit
+++ b/bin/fzf-find-edit
@@ -12,6 +12,10 @@ fail() {
   exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
 }
 
+has() {
+  which "$@" > /dev/null 2>&1
+}
+
 # Functions from https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html
 if has bat; then
   fzf-find-edit() {

--- a/bin/fzf-grep-edit
+++ b/bin/fzf-grep-edit
@@ -12,6 +12,10 @@ fail() {
   exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
 }
 
+has() {
+  which "$@" > /dev/null 2>&1
+}
+
 if ! has rg; then
   fail "Can't find rg - install ripgrep and try again."
 fi

--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -77,3 +77,12 @@ alias fkill='fzf-kill'
 if [[ -d ~/.fzf/man ]]; then
   export MANPATH="$MANPATH:~/.fzf/man"
 fi
+
+if has z; then
+  unalias z 2> /dev/null
+  # like normal z when used with arguments but displays an fzf prompt when used without.
+  z() {
+    [ $# -gt 0 ] && _z "$*" && return
+    cd "$(_z -l 2>&1 | fzf --height 40% --nth 2.. --reverse --inline-info +s --tac --query "${*##-* }" | sed 's/^[0-9,.]* *//')"
+  }
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Add missing `has()` function to `fzf-find-edit` and `fzf-grep-edit`

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
