### PR TITLE
Add a bunch more fzf helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Yes, there is a plugin baked into oh-my-zsh, this allows easy `fzf` integration 
 
 | Name | Description | Author |
 | ---- | ----------- | ------ |
+| `chrome-bookmark-browser` | Rummages through your Chrome bookmarks with `fzf` and opens the selected bookmark(s) in your default browser | [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
 | `fif` | Uses `fzf` and `rg` to find a term in files | [Boost Your Command Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |
 | `fzf-brew-cask-install` | Uses `fzf` to select programs to install (or show the home page) based on the output of `brew cask search` | [Boost Your Command Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |
 | `fzf-brew-cask-uninstall` | Uses `fzf` to select `brew`-installed programs to delete (or show the home page) | [Boost Your Command Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Used by the [zsh-quickstart-kit](https://github.com/unixorn/zsh-quickstart-kit) 
 Yes, there is a plugin baked into oh-my-zsh, this allows easy `fzf` integration for other frameworks, and adds some helper scripts.
 
 ## Contents
+
 | Name | Description | Author |
 | ---- | ----------- | ------ |
 | `fif` | Uses `fzf` and `rg` to find a term in files | [Boost Your Command Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |
@@ -26,3 +27,4 @@ Yes, there is a plugin baked into oh-my-zsh, this allows easy `fzf` integration 
 | `fzf-find-edit` | Uses `fzf` to select files (displaying previews) to edit with `$EDITOR` | [Boost Your Command Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |
 | `fzf-grep-edit` | Uses `fzf` to select files (displaying previews) that contain a search term to edit with `$EDITOR` | [Boost Your Command Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |
 | `fzf-kill` | Uses `fzf` to select processes to kill | [Boost Your Command Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |
+| `tm` | Uses `fzf` to search for a `tmux` session or create one if no matches. | From the [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Yes, there is a plugin baked into oh-my-zsh, this allows easy `fzf` integration 
 | Name | Description | Author |
 | ---- | ----------- | ------ |
 | `chrome-bookmark-browser` | Rummages through your Chrome bookmarks with `fzf` and opens the selected bookmark(s) in your default browser | [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
-| `drm` | Uses `fzf` to select `docker` containers to remove. | From the [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
+| `d-attach` | Uses `fzf` to select `docker` containers to start and attach to. | From the [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
+| `d-image-rm` | Uses `fzf` to select `docker` containers to start and attach to. | From the [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
+| `d-rm` | Uses `fzf` to select `docker` containers to remove. | From the [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
 | `fif` | Uses `fzf` and `rg` to find a term in files | [Boost Your Command Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |
 | `fzf-brew-cask-install` | Uses `fzf` to select programs to install (or show the home page) based on the output of `brew cask search` | [Boost Your Command Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |
 | `fzf-brew-cask-uninstall` | Uses `fzf` to select `brew`-installed programs to delete (or show the home page) | [Boost Your Command Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Yes, there is a plugin baked into oh-my-zsh, this allows easy `fzf` integration 
 | Name | Description | Author |
 | ---- | ----------- | ------ |
 | `chrome-bookmark-browser` | Rummages through your Chrome bookmarks with `fzf` and opens the selected bookmark(s) in your default browser | [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
+| `drm` | Uses `fzf` to select `docker` containers to remove. | From the [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
 | `fif` | Uses `fzf` and `rg` to find a term in files | [Boost Your Command Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |
 | `fzf-brew-cask-install` | Uses `fzf` to select programs to install (or show the home page) based on the output of `brew cask search` | [Boost Your Command Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |
 | `fzf-brew-cask-uninstall` | Uses `fzf` to select `brew`-installed programs to delete (or show the home page) | [Boost Your Command Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |

--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ Yes, there is a plugin baked into oh-my-zsh, this allows easy `fzf` integration 
 | `fzf-kill` | Uses `fzf` to select processes to kill | [Boost Your Command Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |
 | `tm` | Uses `fzf` to search for a `tmux` session or create one if no matches. | From the [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
 | `tmux-search` | Uses `fzf` to select a `tmux` session. Skips `fzf` if there's only one match, exits if no match. | From the [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
+| `vagrant-box-search` | Uses `fzf` to select a `vagrant` box and connect to it with `ssh`. | From the [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |

--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ Yes, there is a plugin baked into oh-my-zsh, this allows easy `fzf` integration 
 | `fzf-grep-edit` | Uses `fzf` to select files (displaying previews) that contain a search term to edit with `$EDITOR` | [Boost Your Command Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |
 | `fzf-kill` | Uses `fzf` to select processes to kill | [Boost Your Command Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |
 | `tm` | Uses `fzf` to search for a `tmux` session or create one if no matches. | From the [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
+| `tmux-search` | Uses `fzf` to select a `tmux` session. Skips `fzf` if there's only one match, exits if no match. | From the [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |

--- a/bin/chrome-bookmark-browser
+++ b/bin/chrome-bookmark-browser
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Chrome Bookmarks browser with jq for OS X
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+function debug() {
+  if [[ -n "$DEBUG" ]]; then
+    echo "$@"
+  fi
+}
+
+function fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+# b - browse chrome bookmarks
+b() {
+
+     jq_script='
+        def ancestors: while(. | length >= 2; del(.[-1,-2]));
+        . as $in | paths(.url?) as $key | $in | getpath($key) | {name,url, path: [$key[0:-2] | ancestors as $a | $in | getpath($a) | .name?] | reverse | join("/") } | .path + "/" + .name + "\t" + .url'
+
+    jq -r "$jq_script" < "$bookmarks_path" \
+        | sed -E $'s/(.*)\t(.*)/\\1\t\x1b[36m\\2\x1b[m/g' \
+        | fzf --ansi \
+        | cut -d$'\t' -f2 \
+        | xargs open
+}
+
+bookmarks_path=~/Library/Application\ Support/Google/Chrome/Default/Bookmarks
+if [[ ! -r "$bookmarks_path" ]]; then
+  fail "Can't read $bookmarks_path"
+fi
+
+myname=$(basename $0)
+if ! has fzf; then
+  fail "$myname requires fzf and can't find it in $PATH"
+fi
+if ! has jq; then
+  fail "$myname requires jq and can't find it in $PATH"
+fi
+
+b "$@"

--- a/bin/chrome-history
+++ b/bin/chrome-history
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# browse Chrome history, then open 
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+function debug() {
+  if [[ -n "$DEBUG" ]]; then
+    echo "$@"
+  fi
+}
+
+function fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+# browse Chrome history
+chrome-history() {
+  local cols sep chrome_history open
+  cols=$(( COLUMNS / 3 ))
+  sep='{::}'
+
+  cp -f "$chrome_history" /tmp/h
+  sqlite3 -separator $sep /tmp/h \
+    "select substr(title, 1, $cols), url
+     from urls order by last_visit_time desc" |
+  awk -F $sep '{printf "%-'$cols's  \x1b[36m%s\x1b[m\n", $1, $2}' |
+  fzf --ansi --multi | sed 's#.*\(https*://\)#\1#' | xargs "$open" > /dev/null 2> /dev/null
+}
+
+if [ "$(uname)" = "Darwin" ]; then
+  chrome_history="$HOME/Library/Application Support/Google/Chrome/Default/History"
+  open=open
+else
+  chrome_history="$HOME/.config/google-chrome/Default/History"
+  open=xdg-open
+fi
+
+if [[ -r "$chrome_history" ]]; then
+  chrome-history "$@"
+else
+  fail "Can't read $chrome_history"
+fi

--- a/bin/d-attach
+++ b/bin/d-attach
@@ -2,7 +2,7 @@
 #
 # Select a docker container to start and attach to
 #
-# From fzf wiki
+# From fzf wiki: https://github.com/junegunn/fzf/wiki/examples
 
 set -o pipefail
 if [[ -n "$DEBUG" ]]; then

--- a/bin/d-attach
+++ b/bin/d-attach
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Select a docker container to start and attach to
+#
+# From fzf wiki
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+function debug() {
+  if [[ -n "$DEBUG" ]]; then
+    echo "$@"
+  fi
+}
+
+function fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+function da() {
+  local cid
+  cid=$(docker ps -a | sed 1d | fzf -1 -q "$1" | awk '{print $1}')
+
+  [ -n "$cid" ] && docker start "$cid" && docker attach "$cid"
+}
+
+if has docker; then
+  dattach "$@"
+else
+  "Cannot find docker in $PATH"
+fi

--- a/bin/d-image-rm
+++ b/bin/d-image-rm
@@ -2,7 +2,7 @@
 #
 # Select a docker image or images to remove
 #
-# From fzf wiki
+# From fzf wiki: https://github.com/junegunn/fzf/wiki/examples
 
 set -o pipefail
 if [[ -n "$DEBUG" ]]; then

--- a/bin/d-image-rm
+++ b/bin/d-image-rm
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Select a docker image or images to remove
+#
+# From fzf wiki
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+function debug() {
+  if [[ -n "$DEBUG" ]]; then
+    echo "$@"
+  fi
+}
+
+function fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+# Select a docker image or images to remove
+function drmi() {
+  docker images | sed 1d | fzf -q "$1" --no-sort -m --tac | awk '{ print $3 }' | xargs -r docker rmi
+}
+
+if has docker; then
+  drmi "$@"
+else
+  "Cannot find docker in $PATH"
+fi

--- a/bin/d-rm
+++ b/bin/d-rm
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Select a docker container to remove
+#
+# From fzf wiki
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+function debug() {
+  if [[ -n "$DEBUG" ]]; then
+    echo "$@"
+  fi
+}
+
+function fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+function drm() {
+  docker ps -a | sed 1d | fzf -q "$1" --no-sort -m --tac | awk '{ print $1 }' | xargs -r docker rm
+}
+
+if has docker; then
+  drm "$@"
+else
+  "Cannot find docker in $PATH"
+fi

--- a/bin/d-stop-container
+++ b/bin/d-stop-container
@@ -2,7 +2,7 @@
 #
 # Select a docker container to remove
 #
-# From fzf wiki: https://github.com/junegunn/fzf/wiki/examples
+# From fzf wiki
 
 set -o pipefail
 if [[ -n "$DEBUG" ]]; then
@@ -25,12 +25,16 @@ function has() {
   which "$@" > /dev/null 2>&1
 }
 
-function drm() {
-  docker ps -a | sed 1d | fzf -q "$1" --no-sort -m --tac | awk '{ print $1 }' | xargs -r docker rm
+# Select a running docker container to stop
+function d-stop-container() {
+  local cid
+  cid=$(docker ps | sed 1d | fzf -q "$1" | awk '{print $1}')
+
+  [ -n "$cid" ] && docker stop "$cid"
 }
 
 if has docker; then
-  drm "$@"
+  d-stop-container "$@"
 else
   "Cannot find docker in $PATH"
 fi

--- a/bin/tm
+++ b/bin/tm
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# tm - create new tmux session, or switch to existing one. Works from within tmux too. (@bag-man)
+# `tm` will allow you to select your tmux session via fzf.
+# `tm irc` will attach to the irc session (if it exists), else it will create it.
+#
+# Source: https://github.com/junegunn/fzf/wiki/examples
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+
+function fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+tm() {
+  [[ -n "$TMUX" ]] && change="switch-client" || change="attach-session"
+  if [ "$1" ]; then
+    tmux $change -t "$1" 2>/dev/null || (tmux new-session -d -s "$1" && tmux $change -t "$1"); return
+  fi
+  session=$(tmux list-sessions -F "#{session_name}" 2>/dev/null | fzf --exit-0) &&  tmux $change -t "$session" || echo "No sessions found."
+}
+
+if has tmux; then
+  tm "$@"
+else
+  fail "Can't find tmux in $PATH"
+fi

--- a/bin/tmux-search
+++ b/bin/tmux-search
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# tm-search [FUZZY PATTERN] - Select selected tmux session
+#   - Bypass fuzzy finder if there's only one match (--select-1)
+#   - Exit if there's no match (--exit-0)
+#
+# From https://github.com/junegunn/fzf/wiki/examples
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+function debug() {
+  if [[ -n "$DEBUG" ]]; then
+    echo "$@"
+  fi
+}
+
+function fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+tm-search() {
+  local session
+  session=$(tmux list-sessions -F "#{session_name}" | \
+    fzf --query="$1" --select-1 --exit-0) &&
+  tmux switch-client -t "$session"
+}
+
+if has tmux; then
+  tm-search "$@"
+else
+  fail "Can't find tmux in $PATH"
+fi

--- a/bin/vagrant-box-search
+++ b/bin/vagrant-box-search
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# List all vagrant boxes available in the system including its status, and try to access the selected one via ssh
+#
+# From the fzf wiki - https://github.com/junegunn/fzf/wiki/examples
+
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+function debug() {
+  if [[ -n "$DEBUG" ]]; then
+    echo "$@"
+  fi
+}
+
+function fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+vagrant-search(){
+  #List all vagrant boxes available in the system including its status, and try to access the selected one via ssh
+  # shellcheck disable=SC2164,SC2046,SC2002
+  cd $(cat "$machine_index" | jq '.machines[] | {name, vagrantfile_path, state}' | jq '.name + "," + .state  + "," + .vagrantfile_path'| sed 's/^"\(.*\)"$/\1/'| column -s, -t | sort -rk 2 | fzf | awk '{print $3}'); exec vagrant ssh
+}
+
+machine_index=~/.vagrant.d/data/machine-index/index
+
+if ! has jq; then
+  fail "Can't find jq in $PATH"
+fi
+if ! has vagrant; then
+  fail "Can't find vagrant in $PATH"
+fi
+if [[ ! -r "$machine_index" ]]; then
+  fail "Can't read $machine_index"
+fi
+
+vagrant-search "$@"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Add a bunch of fzf functions

- `chrome-bookmark-browser` - Search Chrome bookmarks, open them using default browser
- `d-attach` - Start a `docker` container and attach to it
- `d-image-rm` - Select `docker` images and remove them
- `d-rm` - Selects `docker` containers to remove
- `d-stop-container` - Select `docker` container to stop
- `tm` - Select/create tmux session
- `tmux-search` - Select tmux sessions
- `vagrant-box-search` - Find a `vagrant` vm and connect via `ssh`

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
