### PR TITLE
Add tab completion for fzf

### DIFF
--- a/completions/_fzf
+++ b/completions/_fzf
@@ -1,0 +1,61 @@
+#compdef fzf
+
+_arguments \
+         '*:file:_files' \
+		{-x,--extended}'[Extended-search mode. Since 0. 10. 9, this is enabled by default.]' \
+		{-e,--exact}'[Enable exact-match.]' \
+		'-i[Case-insensitive match (default: smart-case match).]' \
+		'--literal[Do not normalize latin script letters for matching.]' \
+		'--algo[Fuzzy matching algorithm (default: v2) .]' \
+		{-n,--nth}'[Comma-separated list of field index expressions for limiting search scope.]' \
+		'--with-nth[Transform the presentation of each line using field index expressions.]' \
+		{-d,--delimiter}'[Field delimiter regex for --nth and --with-nth (default: AWK-style).]' \
+		'--phony[Do not perform search.]' \
+		'--no-sort[Do not sort the result.]' \
+		'--tac[Reverse the order of the input . RS e. g.]' \
+		'--tiebreak[Comma-separated list of sort criteria to apply when the scores are tied. br .]' \
+		{-m,--multi}'[Enable multi-select with tab/shift-tab.]' \
+		'--no-multi[Disable multi-select.]' \
+		'--no-mouse[Disable mouse.]' \
+		'--bind[Comma-separated list of custom key bindings.]' \
+		'--cycle[Enable cyclic scroll.]' \
+		'--keep-right[Keep the right end of the line visible when it'"'"'s too long.]' \
+		'--no-hscroll[Disable horizontal scroll.]' \
+		'--hscroll-off[Number of screen columns to keep to the right of the highlighted substring (d…]' \
+		'--filepath-word[Make word-wise movements and actions respect path separators.]' \
+		'--jump-labels[Label characters for jump and jump-accept . SS Layout.]' \
+		'--height[Display fzf window below the cursor with the given height instead of using th…]' \
+		'--min-height[Minimum height when --height is given in percent (default: 10).]' \
+		'--layout[Choose the layout (default: default) .]' \
+		'--reverse[A synonym for --layout=reverse.]' \
+		'--border[Draw border around the finder .]' \
+		'--no-unicode[Use ASCII characters instead of Unicode box drawing characters to draw border.]' \
+		'--margin[Comma-separated expression for margins around the finder. br . br .]' \
+		'--info[Determines the display style of finder info.]' \
+		'--no-info[A synonym for --info=hidden.]' \
+		'--prompt[Input prompt (default: '"'"'> '"'"').]' \
+		'--pointer[Pointer to the current line (default: '"'"'>'"'"').]' \
+		'--marker[Multi-select marker (default: '"'"'>'"'"').]' \
+		'--header[The given string will be printed as the sticky header.]' \
+		'--header-lines[The first N lines of the input are treated as the sticky header.]' \
+		'--ansi[Enable processing of ANSI color codes.]' \
+		'--tabstop[Number of spaces for a tab character (default: 8).]' \
+		'--color[Color configuration.]' \
+		'--no-bold[Do not use bold text.]' \
+		'--black[Use black background . SS History.]' \
+		'--history[Load search history from the specified file and update the file on completion.]' \
+		'--history-size[Maximum number of entries in the history file (default: 1000).]' \
+		'--preview[Execute the given command for the current line and display the result on the …]' \
+		'--preview-window[Determines the layout of the preview window.]' \
+		{-q,--query}'[Start the finder with the given query.]' \
+		{-1,--select-1}'[Automatically select the only match.]' \
+		{-0,--exit-0}'[Exit immediately when there'"'"'s no match.]' \
+		{-f,--filter}'[Filter mode. Do not start interactive finder.]' \
+		'--print-query[Print query as the first line.]' \
+		'--expect[Comma-separated list of keys that can be used to complete fzf in addition to …]' \
+		'--read0[Read input delimited by ASCII NUL characters instead of newline characters.]' \
+		'--print0[Print output delimited by ASCII NUL characters instead of newline characters.]' \
+		'--no-clear[Do not clear finder interface on exit.]' \
+		'--sync[Synchronous search for multi-staged filtering.]' \
+		'--version[Display version information and exit.]' \
+		'-2[.]'

--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -88,7 +88,7 @@ fi
 if has z; then
   unalias z 2> /dev/null
   # like normal z when used with arguments but displays an fzf prompt when used without.
-  z() {
+  function z() {
     [ $# -gt 0 ] && _z "$*" && return
     cd "$(_z -l 2>&1 | fzf --height 40% --nth 2.. --reverse --inline-info +s --tac --query "${*##-* }" | sed 's/^[0-9,.]* *//')"
   }

--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Add our plugin's bin diretory to user's path
-PLUGIN_BIN="$(dirname $0)/bin"
-export PATH="${PATH}:${PLUGIN_BIN}"
+# Add our plugin's bin diretory to the user's path
+local FZF_PLUGIN_BIN="$(dirname $0)/bin"
+export PATH="${PATH}:${FZF_PLUGIN_BIN}"
+unset FZF_PLUGIN_BIN
 
 function has() {
   which "$@" > /dev/null 2>&1

--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -17,6 +17,10 @@ local FZF_PLUGIN_BIN="$(dirname $0)/bin"
 export PATH="${PATH}:${FZF_PLUGIN_BIN}"
 unset FZF_PLUGIN_BIN
 
+local FZF_COMPLETIONS_D="$(dirname $0)/completions"
+export fpath=($FZF_COMPLETIONS_D "${fpath[@]}" )
+unset FZF_COMPLETIONS_D
+
 function has() {
   which "$@" > /dev/null 2>&1
 }

--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -66,7 +66,7 @@ if has 'fd'; then
 fi
 
 if has tree; then
-  fzf-change-directory() {
+  function fzf-change-directory() {
     local directory=$(
       fd --type d | \
       fzf --query="$1" --no-multi --select-1 --exit-0 \
@@ -96,7 +96,7 @@ fi
 
 # From fzf wiki
 # cdf - cd into the directory of the selected file
-cdf() {
+function cdf() {
   local file
   local dir
   file=$(fzf +m -q "$1") && dir=$(dirname "$file") && cd "$dir"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Add tab completion
- Use `function` consistently
- Fix `z` override

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
