### PR TITLE
Add asdf helper scripts from fzf wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Note - yes, these scripts could all be ZSH functions instead of scripts in the `
 
 | Name | Description | Author |
 | ---- | ----------- | ------ |
+| `asdf-install` | Install one or more versions of the specified language with `fzf` and installs your selection with `asdf` | [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
+| `asdf-uninstall` | Select one or more versions of the specified language with `fzf` and uninstalls your selection with `asdf` | [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
 | `chrome-bookmark-browser` | Rummages through your Chrome bookmarks with `fzf` and opens the selected bookmark(s) in your default browser | [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
 | `d-attach` | Uses `fzf` to select `docker` containers to start and attach to. | From the [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
 | `d-image-rm` | Uses `fzf` to select `docker` containers to start and attach to. | From the [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |

--- a/bin/asdf-fzf-install
+++ b/bin/asdf-fzf-install
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Install one or more versions of specified language
+# e.g. `asdf-install rust` # => fzf multimode, tab to mark, enter to install
+# if no plugin is supplied (e.g. `asdf-install<CR>`), fzf will list them for you
+# Mnemonic [V]ersion [M]anager [I]nstall
+#
+# Source: https://github.com/junegunn/fzf/wiki/examples
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+function fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+# Install one or more versions of specified language
+# e.g. `vmi rust` # => fzf multimode, tab to mark, enter to install
+# if no plugin is supplied (e.g. `vmi<CR>`), fzf will list them for you
+# Mnemonic [V]ersion [M]anager [I]nstall
+asdf-install() {
+  local lang=${1}
+
+  if [[ ! $lang ]]; then
+    lang=$(asdf plugin-list | fzf)
+  fi
+
+  if [[ $lang ]]; then
+    local versions=$(asdf list-all $lang | fzf --tac --no-sort --multi)
+    if [[ $versions ]]; then
+      for version in $(echo $versions);
+      do; asdf install $lang $version; done;
+    fi
+  fi
+}
+
+if has asdf; then
+  asdf-install "$@"
+else
+  fail "Can't find asdf in $PATH"
+fi

--- a/bin/asdf-fzf-remove
+++ b/bin/asdf-fzf-remove
@@ -1,0 +1,1 @@
+asdf-fzf-uninstall

--- a/bin/asdf-fzf-uninstall
+++ b/bin/asdf-fzf-uninstall
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Remove one or more versions of specified language
+# e.g. `asdf-remove rust` # => fzf multimode, tab to mark, enter to remove
+# if no plugin is supplied (e.g. `asdf-remove<CR>`), fzf will list them for you
+#
+# Source: https://github.com/junegunn/fzf/wiki/examples
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+function fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+# Remove one or more versions of specified language
+# e.g. `vmi rust` # => fzf multimode, tab to mark, enter to remove
+# if no plugin is supplied (e.g. `vmi<CR>`), fzf will list them for you
+asdf-remove() {
+  local lang=${1}
+
+  if [[ ! $lang ]]; then
+    lang=$(asdf plugin-list | fzf)
+  fi
+
+  if [[ $lang ]]; then
+    local versions=$(asdf list $lang | fzf -m)
+    if [[ $versions ]]; then
+      for version in $(echo $versions);
+      do; asdf uninstall $lang $version; done;
+    fi
+  fi
+}
+
+if has asdf; then
+  asdf-remove "$@"
+else
+  fail "Can't find asdf in $PATH"
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Add `asdf-install`, `asdf-uninstall` scripts from wiki
- Add `asdf-remove` as symlink to `asdf-uninstall` so I don't have to remember whether it uses `uninstall` or `remove` to remove language binaries

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
