### PR TITLE
Shellcheck fixes and default opt updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Note - yes, these scripts could all be ZSH functions instead of scripts in the `
 
 ## Installing
 
+You probably want this plugin to be last in your framework's list of plugins to load. It dynamically generates `$FZF_DEFAULT_OPT` and `$FZF_DEFAULT_COMMAND` based on whether it sees things like `rg` and `bat` in your `$PATH`, so it should come after other plugins have had a chance to extend `$PATH`.
+
 ### Zgenom
 
 add `zgenom load unixorn/fzf-zsh-plugin` to your `.zshrc` with your other load commands.

--- a/bin/apt-fzf-search
+++ b/bin/apt-fzf-search
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Use fzf to filter apt-cache search results
+#
+# From https://www.linuxuprising.com/2021/03/a-quick-introduction-to-fzf-interactive.html
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+function debug() {
+  if [[ -n "$DEBUG" ]]; then
+    echo "$@"
+  fi
+}
+
+function fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+if has apt-cache; then
+  apt-cache search "$@" | \
+  sort | \
+  cut --delimiter ' ' --fields 1 | \
+  fzf --multi --cycle --reverse --preview 'apt-cache show {1}' | \
+  xargs -r sudo apt install -y
+else
+  fail "Cannot find apt in $PATH. 
+  
+Are you sure you're on a Debian or Ubuntu system?"
+fi

--- a/bin/asdf-fzf-install
+++ b/bin/asdf-fzf-install
@@ -34,10 +34,13 @@ asdf-install() {
   fi
 
   if [[ $lang ]]; then
-    local versions=$(asdf list-all $lang | fzf --tac --no-sort --multi)
+    local versions
+    versions=$(asdf list-all "$lang" | fzf --tac --no-sort --multi)
     if [[ $versions ]]; then
-      for version in $(echo $versions);
-      do; asdf install $lang $version; done;
+      for version in $versions
+      do
+        asdf install "$lang" "$version"
+      done
     fi
   fi
 }

--- a/bin/asdf-fzf-uninstall
+++ b/bin/asdf-fzf-uninstall
@@ -32,10 +32,13 @@ asdf-remove() {
   fi
 
   if [[ $lang ]]; then
-    local versions=$(asdf list $lang | fzf -m)
+    local versions
+    versions=$(asdf list "$lang" | fzf -m)
     if [[ $versions ]]; then
-      for version in $(echo $versions);
-      do; asdf uninstall $lang $version; done;
+      for version in $versions
+      do
+        asdf uninstall "$lang" "$version"
+      done
     fi
   fi
 }

--- a/bin/chrome-bookmark-browser
+++ b/bin/chrome-bookmark-browser
@@ -26,7 +26,8 @@ function has() {
 # b - browse chrome bookmarks
 b() {
 
-     jq_script='
+    # shellcheck disable=SC2016
+    jq_script='
         def ancestors: while(. | length >= 2; del(.[-1,-2]));
         . as $in | paths(.url?) as $key | $in | getpath($key) | {name,url, path: [$key[0:-2] | ancestors as $a | $in | getpath($a) | .name?] | reverse | join("/") } | .path + "/" + .name + "\t" + .url'
 
@@ -42,7 +43,7 @@ if [[ ! -r "$bookmarks_path" ]]; then
   fail "Can't read $bookmarks_path"
 fi
 
-myname=$(basename $0)
+myname=$(basename "$0")
 if ! has fzf; then
   fail "$myname requires fzf and can't find it in $PATH"
 fi

--- a/bin/fzf-brew-install
+++ b/bin/fzf-brew-install
@@ -22,12 +22,15 @@ fi
 
 # Install (one or multiple) selected application(s)
 # using "brew search" as source input
-fzf-brew-install() {
-  inst=$(brew search | fzf -m)
+function fzf-brew-install(){
+  # shellcheck disable=SC2068
+  inst=$(brew search $@ | fzf -m)
 
   if [[ $inst ]]; then
-    for prog in $(echo $inst);
-    do; brew install $prog; done;
+    for prog in $inst
+    do
+      brew install "$prog"
+    done
   fi
 }
 

--- a/bin/fzf-brew-uninstall
+++ b/bin/fzf-brew-uninstall
@@ -25,8 +25,10 @@ fzf-brew-uninstall() {
   uninst=$(brew leaves | fzf -m)
 
   if [[ $uninst ]]; then
-    for prog in $(echo $uninst);
-    do; brew uninstall $prog; done;
+    for prog in $uninst
+    do
+      brew uninstall "$prog"
+    done
   fi
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- dynamically generate `$FZF_DEFAULT_OPTS` based on what commands are available in `$PATH`
- shellcheck cleanups of `asdf-fzf-*`, `fzf-brew-*`, `chrome-bookmark-browser`

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
