### PR TITLE
fix tiny typo

### DIFF
--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Add our plugin's bin diretory to the user's path
+# Add our plugin's bin directory to the user's path
 local FZF_PLUGIN_BIN="$(dirname $0)/bin"
 export PATH="${PATH}:${FZF_PLUGIN_BIN}"
 unset FZF_PLUGIN_BIN


### PR DESCRIPTION
# Description

Fix "diretory" to "directory" in comment on line 15.

# Checklist

- [X] All new and existing tests pass.
- [ ] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [X] I have read the **CONTRIBUTING** document.

# License Acceptance

- [X] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

p.s. Please feel to close this PR un-merged and just include the change in your next regular update of consequence; I don't want to clutter your git history with trivialities like this but still figured you'd want everything to read as professionally as the code itself does... :) Thanks for sharing your code!