### PR TITLE
Fix clone command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ add `antigen bundle unixorn/fzf-zsh-plugin` to your `.zshrc`
 ### [Oh-My-Zsh](http://ohmyz.sh/)
 
 1. `cd ~/.oh-my-zsh/custom/plugins`
-2. `git clone git@github.com:unixorn/fzf-zsh-plugin.git fzf-zsh`
+2. `git clone https://github.com/unixorn/fzf-zsh-plugin.git fzf-zsh`
 3. Add tumult to your plugin list - edit `~.zshrc` and change `plugins=(...)` to `plugins=(... fzf-zsh)`
 
 ### Without using a framework


### PR DESCRIPTION
# Description

Using the clone command provided in the readme fails:
```bash
git clone git@github.com:unixorn/fzf-zsh-plugin.git fzf-zsh
Cloning into 'fzf-zsh'...
The authenticity of host 'github.com (140.82.121.3)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,140.82.121.3' (RSA) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```

With `https://github.com/unixorn/fzf-zsh-plugin.git` it works:

```bash
git clone https://github.com/unixorn/fzf-zsh-plugin.git fzf-zsh
Cloning into 'fzf-zsh'...
remote: Enumerating objects: 252, done.
remote: Counting objects: 100% (252/252), done.
remote: Compressing objects: 100% (127/127), done.
remote: Total 252 (delta 134), reused 233 (delta 120), pack-reused 0
Receiving objects: 100% (252/252), 57.71 KiB | 253.00 KiB/s, done.
Resolving deltas: 100% (134/134), done.
```

# Checklist

- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
