### PR TITLE
Fix race condition if two chrome-history scripts ran at once

### DIFF
--- a/bin/chrome-history
+++ b/bin/chrome-history
@@ -45,8 +45,8 @@ chrome-history() {
   cols=$(( COLUMNS / 3 ))
   sep='{::}'
 
-  cp -f "$chrome_history" ${SCRATCH_D}/chrome-history.sqlite
-  sqlite3 -separator $sep ${SCRATCH_D}/chrome-history.sqlite \
+  cp -f "$chrome_history" "${SCRATCH_D}/chrome-history.sqlite"
+  sqlite3 -separator $sep "${SCRATCH_D}/chrome-history.sqlite" \
     "select substr(title, 1, $cols), url
      from urls order by last_visit_time desc" |
   awk -F $sep '{printf "%-'$cols's  \x1b[36m%s\x1b[m\n", $1, $2}' |

--- a/bin/chrome-history
+++ b/bin/chrome-history
@@ -23,14 +23,30 @@ function has() {
   which "$@" > /dev/null 2>&1
 }
 
+function cleanup() {
+  if [[ -d "$SCRATCH_D" ]]; then
+    rm -fr "$SCRATCH_D"
+  fi  
+}  
+
+# Set up a working scratch directory
+SCRATCH_D=$(mktemp -d)
+
+if [[ ! "$SCRATCH_D" || ! -d "$SCRATCH_D" ]]; then
+  echo "Could not create temp dir"
+  exit 1
+fi  
+
+trap cleanup EXIT
+
 # browse Chrome history
 chrome-history() {
   local cols sep chrome_history open
   cols=$(( COLUMNS / 3 ))
   sep='{::}'
 
-  cp -f "$chrome_history" /tmp/h
-  sqlite3 -separator $sep /tmp/h \
+  cp -f "$chrome_history" ${SCRATCH_D}/chrome-history.sqlite
+  sqlite3 -separator $sep ${SCRATCH_D}/chrome-history.sqlite \
     "select substr(title, 1, $cols), url
      from urls order by last_visit_time desc" |
   awk -F $sep '{printf "%-'$cols's  \x1b[36m%s\x1b[m\n", $1, $2}' |


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

# Description

Wasn't using a unique path to the temporary copy of the history file, make a scratch directory with `mktemp` and put the file there so we don't have a collision if two copies of the script are running simultaneously.


# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [ ] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
