### PR TITLE
Fix unable to launch vim via ctrl-e

### DIFF
--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -99,7 +99,7 @@ if [[ -z "$FZF_DEFAULT_OPTS" ]]; then
   --prompt='∼ ' --pointer='▶' --marker='✓'
   --bind '?:toggle-preview'
   --bind 'ctrl-a:select-all'
-  --bind 'ctrl-e:execute(echo {+} | xargs -o vim)'
+  --bind 'ctrl-e:execute(vim {+} >/dev/tty)'
   --bind 'ctrl-v:execute(code {+})'
   "
 


### PR DESCRIPTION
The current command doesn't work for me for some reason. Please verify that this works as I run this in WSL, which itself could be the problem.

Signed-off-by: Patrick Li <patrick@papaq.org>