### PR TITLE
Install after cloning for getting the binary file

### DIFF
--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -51,6 +51,7 @@ unset xdg_path
 if ! has fzf; then
   if [[ ! -d $fzf_path ]]; then
     git clone --depth 1 https://github.com/junegunn/fzf.git $fzf_path
+    $fzf_path/install --bin
   fi
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

I tried to install it by using you plugin but it fails because it doesn't generate the binary file "fzf".

According to the junegunn/fzf repo, in order to install it by using git, you have to execute "install" script after cloning.

Documentation: https://github.com/junegunn/fzf#using-git

These are the options for the installer in case you need:

    --help               Show this message

    --bin                Download fzf binary only; Do not generate ~/.fzf.{bash,zsh}

    --all                Download fzf binary and update configuration files
                         to enable key bindings and fuzzy completion

    --xdg                Generate files under \$XDG_CONFIG_HOME/fzf

    --[no-]key-bindings  Enable/disable key bindings (CTRL-T, CTRL-R, ALT-C)

    --[no-]completion    Enable/disable fuzzy completion (bash & zsh)

    --[no-]update-rc     Whether or not to update shell configuration files

    --no-bash            Do not set up bash configuration

    --no-zsh             Do not set up zsh configuration

    --no-fish            Do not set up fish configuration

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [X] I have confirmed that the link(s) in my PR are valid.
- [X] I have read the **CONTRIBUTING** document.

# License Acceptance

- [X] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
