### PR TITLE
Add "brew info" as fzf preview option where missing for homebrew fzf commands

### DIFF
--- a/bin/fzf-brew-install
+++ b/bin/fzf-brew-install
@@ -24,7 +24,7 @@ fi
 # using "brew search" as source input
 function fzf-brew-install(){
   # shellcheck disable=SC2068
-  inst=$(brew search $@ | fzf -m)
+  inst=$(brew search $@ | fzf -m --preview 'brew info {}')
 
   if [[ $inst ]]; then
     for prog in $inst

--- a/bin/fzf-brew-uninstall
+++ b/bin/fzf-brew-uninstall
@@ -22,7 +22,7 @@ fi
 
 # Delete (one or multiple) selected application(s)
 fzf-brew-uninstall() {
-  uninst=$(brew leaves | fzf -m)
+  uninst=$(brew leaves | fzf -m --preview 'brew info {}')
 
   if [[ $uninst ]]; then
     for prog in $uninst

--- a/bin/fzf-brew-update
+++ b/bin/fzf-brew-update
@@ -22,7 +22,7 @@ fi
 
 # Update (one or multiple) selected application(s)
 brew-update-plugin() {
-  upd=$(brew leaves | fzf -m)
+  upd=$(brew leaves | fzf -m --preview 'brew info {}')
 
   if [[ $upd ]]; then
     # shellcheck disable=SC2086


### PR DESCRIPTION
Multiple brew commands were missing --preview 'brew info {}'

# Description

Adds "--preview 'brew info {}'" argument to:
- bin/ff-brew-install
- bin/fzf-brew-uninstall
- bin/ff-brew-update

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [X] All new and existing tests pass.
- [ ] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [X] Scripts are marked executable
- [X] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [X] I have confirmed that the link(s) in my PR are valid.
- [X] I have read the **CONTRIBUTING** document.

# License Acceptance

- [X] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
