### PR TITLE
Fix bug when `FZF_PREVIEW_WINDOW` is undefined

### DIFF
--- a/bin/fif
+++ b/bin/fif
@@ -14,7 +14,9 @@ fif() {
     echo "Need a string to search for!";
     return 1;
   fi
-  rg --files-with-matches --no-messages "$1" | fzf "$FZF_PREVIEW_WINDOW" --preview "rg --ignore-case --pretty --context 10 '$1' {}"
+  # if FZF_PREVIEW_WINDOW is undefined, quoting it breaks the script
+  # shellcheck disable=SC2086
+  rg --files-with-matches --no-messages "$1" | fzf $FZF_PREVIEW_WINDOW --preview "rg --ignore-case --pretty --context 10 '$1' {}"
 }
 
 command -v rg >/dev/null


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

# Description

Fixes issue caused in https://github.com/unixorn/fzf-zsh-plugin/commit/0578f7e3dda91ae3997cb8066885305be83274c4

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
