### PR TITLE
Extract FZF_PREVIEW_WINDOW to allow customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Add `zgenom load unixorn/fzf-zsh-plugin` to your `.zshrc` with your other load c
 
 Add `antigen bundle unixorn/fzf-zsh-plugin@main` to your `.zshrc`
 
-☝  **Note** that until https://github.com/zsh-users/antigen/issues/717 gets fixed in Antigen, it only recognizes plugins in `master` branch. So you need to explicitly specify `@main` here.
+☝  **Note** that until <https://github.com/zsh-users/antigen/issues/717> gets fixed in Antigen, it only recognizes plugins in `master` branch. So you need to explicitly specify `@main` here.
 
 ### [Oh-My-Zsh](http://ohmyz.sh/)
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ Add `antigen bundle unixorn/fzf-zsh-plugin@main` to your `.zshrc`
 
 The scripts in this collection don't actually require you to be using ZSH as your login shell, they're being distributed as an [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh)-compatible plugin because it's convenient for me.
 
+### Customization
+
+You can customize a few features by exporting the following environment variables:
+
+- `export FZF_PREVIEW_WINDOW=''` – you can set any value supported by `fzf --preview-window` option, e.g. `right:65%:nohidden` will show the preview by default.
+
 ## Other FZF resources
 
 - [Fuzzy Git Checkout](https://polothy.github.io/post/2019-08-19-fzf-git-checkout/) - Mark Nielsen wrote a good blog post showing how to use [fzf](https://github.com/junegunn/fzf) for `git` checkouts.

--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -97,13 +97,15 @@ if [[ -z "$FZF_DEFAULT_COMMAND" ]]; then
   unset _fd_cmd
 fi
 
-# Don't step on a user's existing FZF_DEFAULT_OPTS
+# Don't step on user's defined variables
+[[ -z "$FZF_PREVIEW_WINDOW" ]] && export FZF_PREVIEW_WINDOW=':hidden'
 if [[ -z "$FZF_DEFAULT_OPTS" ]]; then
-  export FZF_DEFAULT_OPTS="--layout=reverse
+  export FZF_DEFAULT_OPTS="
+  --layout=reverse
   --info=inline
   --height=80%
   --multi
-  --preview-window=:hidden
+  --preview-window=${FZF_PREVIEW_WINDOW}
   --color='hl:148,hl+:154,pointer:032,marker:010,bg+:237,gutter:008'
   --prompt='∼ ' --pointer='▶' --marker='✓'
   --bind '?:toggle-preview'


### PR DESCRIPTION
# Description

By default the preview is hidden but the user can decide how to set the
preview by setting this environment variable. The value will also be
taken by other scripts like `fif`.

Signed-off-by: Gerard Bosch <gerard.bosch@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->



<!--- Describe your changes in detail -->

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
