### PR TITLE
Format FZF_DEFAULT_OPTS value

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Note - while these scripts could all be ZSH functions instead of scripts in the 
 | `d-image-rm` | Uses `fzf` to select `docker` containers to start and attach to. | From the [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
 | `d-rm` | Uses `fzf` to select `docker` containers to remove. | From the [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
 | `d-stop-container` | Stop a Docker container. | |
+| `falias` | Searches your ZSH aliases, then puts your selection on the mac clipboard (macOS only) | |
 | `fif` | Uses `fzf` and `rg` to find a term in files | [Boost Your Command-Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |
 | `fzf-brew-cask-install` | Uses `fzf` to select programs to install (or show the home page) based on the output of `brew cask search` | [Boost Your Command-Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |
 | `fzf-brew-cask-uninstall` | Uses `fzf` to select `brew`-installed programs to delete (or show the home page) | [Boost Your Command-Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Note - while these scripts could all be ZSH functions instead of scripts in the 
 | `d-attach` | Uses `fzf` to select `docker` containers to start and attach to. | From the [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
 | `d-image-rm` | Uses `fzf` to select `docker` containers to start and attach to. | From the [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
 | `d-rm` | Uses `fzf` to select `docker` containers to remove. | From the [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
-| `falias` | Searches your ZSH aliases, then puts your selection on the mac clipboard (macOS only) | |
+| `d-stop-container` | Stop a Docker container. | |
 | `fif` | Uses `fzf` and `rg` to find a term in files | [Boost Your Command-Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |
 | `fzf-brew-cask-install` | Uses `fzf` to select programs to install (or show the home page) based on the output of `brew cask search` | [Boost Your Command-Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |
 | `fzf-brew-cask-uninstall` | Uses `fzf` to select `brew`-installed programs to delete (or show the home page) | [Boost Your Command-Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |

--- a/bin/d-stop-container
+++ b/bin/d-stop-container
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Select a docker container to remove
+# Stop a docker container
 #
 # From fzf wiki
 

--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -81,7 +81,7 @@ if [[ -z "$FZF_DEFAULT_COMMAND" ]]; then
   # If fd command is installed, use it instead of find
   _fzf_has 'fd' && _fd_cmd="fd"
   _fzf_has 'fdfind' && _fd_cmd="fdfind"
-  if [[ -n $_fd_cmd ]] then
+  if [[ -n "$_fd_cmd" ]]; then
     # Show hidden, and exclude .git and the pigsty node_modules files
     export FZF_DEFAULT_COMMAND="$_fd_cmd --hidden --follow --exclude '.git' --exclude 'node_modules'"
     export FZF_ALT_C_COMMAND="$FZF_DEFAULT_COMMAND --type d"
@@ -100,29 +100,30 @@ fi
 # Don't step on user's defined variables
 [[ -z "$FZF_PREVIEW_WINDOW" ]] && export FZF_PREVIEW_WINDOW=':hidden'
 if [[ -z "$FZF_DEFAULT_OPTS" ]]; then
-  export FZF_DEFAULT_OPTS="
-  --layout=reverse
-  --info=inline
-  --height=80%
-  --multi
-  --preview-window=${FZF_PREVIEW_WINDOW}
-  --color='hl:148,hl+:154,pointer:032,marker:010,bg+:237,gutter:008'
-  --prompt='∼ ' --pointer='▶' --marker='✓'
-  --bind '?:toggle-preview'
-  --bind 'ctrl-a:select-all'
-  --bind 'ctrl-e:execute(vim {+} >/dev/tty)'
-  --bind 'ctrl-v:execute(code {+})'
-  "
-
+  fzf_default_opts+=(
+    "--layout=reverse"
+    "--info=inline"
+    "--height=80%"
+    "--multi"
+    "--preview-window='${FZF_PREVIEW_WINDOW}'"
+    "--color='hl:148,hl+:154,pointer:032,marker:010,bg+:237,gutter:008'"
+    "--prompt='∼ '"
+    "--pointer='▶'"
+    "--marker='✓'"
+    "--bind '?:toggle-preview'"
+    "--bind 'ctrl-a:select-all'"
+    "--bind 'ctrl-e:execute(vim {+} >/dev/tty)'"
+    "--bind 'ctrl-v:execute(code {+})'"
+  )
   if _fzf_has bat; then
     # bat will syntax colorize files for you
-    export FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --preview '([[ -f {} ]] && (bat --style=numbers --color=always {} || cat {})) || ([[ -d {} ]] && (tree -C {} | less)) || echo {} 2> /dev/null | head -200'"
+    fzf_default_opts+=("--preview '([[ -f {} ]] && (bat --style=numbers --color=always {} || cat {})) || ([[ -d {} ]] && (tree -C {} | less)) || echo {} 2> /dev/null | head -200'")
   fi
-
   if _fzf_has pbcopy; then
-    # on macOS, make ^Y yank the selection to the system clipboard
-    export FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --bind 'ctrl-y:execute-silent(echo {+} | pbcopy)'"
+    # On macOS, make ^Y yank the selection to the system clipboard. On Linux you can alias pbcopy to `xclip -selection clipboard` or corresponding tool.
+    fzf_default_opts+=("--bind 'ctrl-y:execute-silent(echo {+} | pbcopy)'")
   fi
+  export FZF_DEFAULT_OPTS=$(printf '%s\n' "${fzf_default_opts[@]}")
 fi
 
 if _fzf_has tree; then


### PR DESCRIPTION
# Description

Properly formatting the options allow to print them nicely:
```
echo $FZF_DEFAULT_OPTS
```
will print one option per line, all with same indentation.

This makes understanding its value easier.

Here is the comparison before/after:

![image](https://user-images.githubusercontent.com/30733556/155562375-25f5a365-33db-437a-8eca-e5e22b7a8358.png)

Signed-off-by: Gerard Bosch <gerard.bosch@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
