### PR TITLE
Install fzf if not found in home.

### DIFF
--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -45,11 +45,9 @@ fi
 unset xdg_path
 
 # Install fzf into ~ if it hasn't already been installed.
-if ! _fzf_has fzf; then
-  if [[ ! -d $FZF_PATH ]]; then
-    git clone --depth 1 https://github.com/junegunn/fzf.git $FZF_PATH
-    $FZF_PATH/install --bin
-  fi
+if [[ ! -d $FZF_PATH ]]; then
+  git clone --depth 1 https://github.com/junegunn/fzf.git $FZF_PATH
+  $FZF_PATH/install --bin
 fi
 
 # Install some default settings if user doesn't already have fzf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Fixes https://github.com/unixorn/fzf-zsh-plugin/issues/52.

The script currently does not install fzf in the home directory if `which fzf` returns true. This is why users are having problems when they have fzf installed globally. This change always installs fzf if the fzf home directory does not exist.

<!--- Describe your changes in detail -->

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
