### PR TITLE
Custom fzf install directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ You can customize a few features by exporting the following environment variable
 | ---------------------------------- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `export FZF_PREVIEW_ADVANCED=true` | Use `less` viewer with a pre-processor to display improved previews for a wide range of files (requires you to install at least `exa`, `bat`, `chafa`, `exiftool`; and very recommended `lesspipe.sh` and the tools it uses underneath: `mdcat`, `in2csv`,...). _This is an opt-in feature._ |
 | `export FZF_PREVIEW_WINDOW=''`     | Set any value supported by `fzf --preview-window` option, e.g. `right:65%:nohidden` will show the preview by default.                                                                                                                                                                        |
+| `export FZF_PATH=''`               | Path to install fzf binary and script, e.g. `${HOME}/.config/fzf`.                                                                            |
 
 ### A note on `lessfilter-fzf`
 

--- a/fzf-settings.zsh
+++ b/fzf-settings.zsh
@@ -1,14 +1,14 @@
 # Setup fzf
 # ---------
-if [[ ! "$PATH" == *${HOME}/.fzf/bin* ]]; then
-  export PATH="$PATH:${HOME}/.fzf/bin"
+if [[ ! "$PATH" == *${FZF_PATH}/bin* ]]; then
+  export PATH="$PATH:${FZF_PATH}/bin"
 fi
 
 # Auto-completion
 # ---------------
-[[ $- == *i* ]] && source "${HOME}/.fzf/shell/completion.zsh" 2> /dev/null
+[[ $- == *i* ]] && source "${FZF_PATH}/shell/completion.zsh" 2> /dev/null
 
 # Key bindings
 # ------------
-source "${HOME}/.fzf/shell/key-bindings.zsh"
+source "${FZF_PATH}/shell/key-bindings.zsh"
 

--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -35,23 +35,20 @@ function _fzf_debugOut() {
 # file searching.
 
 # Determine where fzf is installed
-local xdg_path="${XDG_CONFIG_HOME:-$HOME/.config}"
-local fzf_path
 local fzf_conf
-if [[ -d "$xdg_path/fzf" ]]; then
-  fzf_path="$xdg_path/fzf"
-  fzf_conf="$fzf_path/fzf.zsh"
-else
-  fzf_path=~/.fzf
+if [[ -z "$FZF_PATH" ]]; then
+  FZF_PATH=~/.fzf
   fzf_conf=~/.fzf.zsh
+else
+  fzf_conf="$FZF_PATH/fzf.zsh"
 fi
 unset xdg_path
 
 # Install fzf into ~ if it hasn't already been installed.
 if ! _fzf_has fzf; then
-  if [[ ! -d $fzf_path ]]; then
-    git clone --depth 1 https://github.com/junegunn/fzf.git $fzf_path
-    $fzf_path/install --bin
+  if [[ ! -d $FZF_PATH ]]; then
+    git clone --depth 1 https://github.com/junegunn/fzf.git $FZF_PATH
+    $FZF_PATH/install --bin
   fi
 fi
 
@@ -153,10 +150,9 @@ fi
 
 alias fkill='fzf-kill'
 
-if [[ -d $fzf_path/man ]]; then
-    manpath+=("$MANPATH:$fzf_path/man")
+if [[ -d $FZF_PATH/man ]]; then
+    manpath+=("$MANPATH:$FZF_PATH/man")
 fi
-unset fzf_path
 
 if _fzf_has z; then
   unalias z 2> /dev/null


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Allows user to specify a custom fzf install directory. By default, it is still installed in `~/.fzf`.

My main motivation is that I would prefer to install in `~/.config`. The current support for this is broken, as `fzf-settings.zsh` only sources from `~/.fzf`. In addition, the scripts only installs in `~/.config` when `~/.config/fzf` is present, but this requires users deliberately creating this directory, and no one would know since there is no documentation for this.

As an alternative, I have [another branch](https://github.com/caojoshua/fzf-zsh-plugin/tree/config) where I implemented installing in `~/.config` by default. Not sure if this is a good idea though, because it will change the install locations for current users and may be breaking.

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
