### PR TITLE
Stifle warnings in `lesspipe.sh`

### DIFF
--- a/bin/lessfilter-fzf
+++ b/bin/lessfilter-fzf
@@ -42,7 +42,7 @@ elif [ "$category" = image ] && has_cmd chafa && has_cmd exiftool; then
 elif has_cmd lesspipe.sh; then
   # At the time of writing, `lesspipe.sh` does not use `exa` and `chafa`, it just uses `ls` and `exiftool`. It
   # will ultimately rely on `less` as a sane fallback.
-  lesspipe.sh "$1"
+  lesspipe.sh "$1" 2>/dev/null
 elif [ "$category" = text ] && has_cmd bat; then  # <-- give priority to lesspipe.sh if available
 	bat "$1"
 else


### PR DESCRIPTION
# Description

Stifle warnings in `lesspipe.sh`

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
