### PR TITLE
Add mcarey's vscode helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Note - while these scripts could all be ZSH functions instead of scripts in the 
 | `fzf-git-checkout` | Uses `fzf` to check out a branch in a `git` repository | From Mark Nielsen's [Fuzzy Git Checkout](https://polothy.github.io/post/2019-08-19-fzf-git-checkout/) article |
 | `fzf-grep-edit` | Uses `fzf` to select files (displaying previews) that contain a search term to edit with `$EDITOR` | [Boost Your Command-Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |
 | `fzf-kill` | Uses `fzf` to select processes to kill | [Boost Your Command-Line Productivity With Fuzzy Finder](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d) |
+| `fzf-vscode` | Uses `fzf` and `rg` to search for text and then open the file in vscode | Hangops post by Mark Carey |
 | `lessfilter-fzf` | A less pre-processor to nicely display a wide range of file formats, including images and directories that can be used to show fzf previews (see [Customization](#customization) section). | [Aloxaf/fzf-tab - Wiki/Preview](https://github.com/Aloxaf/fzf-tab/wiki/Preview) |
 | `pr-list` | Use `fzf` to select a PR using `gh` | ? |
 | `tm` | Uses `fzf` to search for a `tmux` session or create one if there are no matches. | From the [fzf wiki](https://github.com/junegunn/fzf/wiki/examples) |
@@ -95,7 +96,7 @@ Optionally, to make the most out of `fzf` preview (`?` toggle), install the foll
 - `bat` - a `cat` clone with syntax highlighting and Git integration,
 - `chafa` - show images (the image can look better or worse depending on the terminal app you use),
 - `exiftool` - also show image metadata,
-- `lesspipe.sh`, e.g. `brew install lesspipe` - and other optional tools `lesspipe.sh` relies on. See <https://github.com/wofr06/lesspipe>  
+- `lesspipe.sh`, e.g. `brew install lesspipe` - and other optional tools `lesspipe.sh` relies on. See <https://github.com/wofr06/lesspipe>
   ☝ **Note**: This is not the `lesspipe` already bundled in Ubuntu/Debian but an improved one (while package is called `lesspipe`, the binary is `lesspipe.sh`).
 
 ## Customization

--- a/bin/fzf-vscode
+++ b/bin/fzf-vscode
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Based on Mark's script posted to hangops, which in turn was based on
+# the example at https://github.com/junegunn/fzf/blob/master/ADVANCED.md#ripgrep-integration
+#
+# Copyright 2023, Mark Carey
+#
+# shellcheck disable=SC2086
+#
+# 1. Search for text in files using Ripgrep
+# 2. Interactively narrow down the list using fzf
+# 3. Open the file in vscode
+
+set -euo pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+function debug() {
+  if [[ -n "$DEBUG" ]]; then
+    echo "$@"
+  fi
+}
+
+function echo-stderr() {
+  echo "$@" 1>&2  ## Send message to stderr.
+}
+
+function fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+function has() {
+  # Check if a command is in $PATH
+  which "$@" > /dev/null 2>&1
+}
+
+# shellcheck disable=SC2016
+function check-dependencies() {
+  if ! has code; then
+    fail 'Could not find code in your $PATH.'
+  fi
+  if ! has fzf; then
+    fail 'Could not find fzf in your $PATH. Installation instructions are at https://github.com/junegunn/fzf'
+  fi
+  if ! has rg; then
+    fail 'Could not find rg in your $PATH. Installation instructions are at https://github.com/BurntSushi/ripgrep'
+  fi
+}
+
+check-dependencies
+
+while getopts n OPTION
+do
+  case "${OPTION}" in
+    n) NEW_WINDOW="--new-window";;
+    *) echo "ERROR: we only support -n" && exit 1;;
+  esac
+done
+shift $((OPTIND-1))
+
+: "${NEW_WINDOW:=""}"
+
+ARGLIST=""
+while IFS=: read -ra SELECTED; do
+  if [ "${#SELECTED[@]}" -gt 0 ]; then
+    ARGLIST+="--goto ${SELECTED[0]}:${SELECTED[1]} "
+  fi
+done < <(
+  rg --color=always --line-number --no-heading --smart-case "${*:-}" |
+    fzf --ansi \
+        --color "hl:-1:underline,hl+:-1:underline:reverse" \
+        --delimiter : \
+        --multi \
+        --preview 'bat --color=always {1} --highlight-line {2}' \
+        --preview-window 'up,60%,border-bottom,+{2}+3/3,~3'
+)
+if [ -n "${ARGLIST}" ]; then
+  code ${NEW_WINDOW} ${ARGLIST}
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Mark posted a handy script to search files with `rg` and `fzf` and edit them with VS Code.

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
