### PR TITLE
Add `--depth 1` to git clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ Add `antigen bundle unixorn/fzf-zsh-plugin@main` to your `.zshrc`
 
 ### [Oh-My-Zsh](http://ohmyz.sh/)
 
-1. `git clone https://github.com/unixorn/fzf-zsh-plugin.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/fzf-zsh-plugin`
+1. `git clone --depth 1 https://github.com/unixorn/fzf-zsh-plugin.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/fzf-zsh-plugin`
 2. Add **fzf-zsh-plugin** to your plugin list - edit `~.zshrc` and change `plugins=(...)` to `plugins=(... fzf-zsh-plugin)`
 
 ### Without using a framework
 
-1. `git clone git@github.com:unixorn/fzf-zsh-plugin.git`, then add its `bin` directory to your `$PATH`.
+1. `git clone --depth 1 git@github.com:unixorn/fzf-zsh-plugin.git`, then add its `bin` directory to your `$PATH`.
 2. Add `source /path/to/repository/checkout/fzf-zsh-plugin.plugin.zsh` to your `.zshrc` file.
 
 The scripts in this collection don't actually require you to be using ZSH as your login shell, they're being distributed as an [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh)-compatible plugin because it's convenient for me.


### PR DESCRIPTION

The current implementations clone the entire history of this project.
Now it only clones the last changes, decreasing the size of the directory

https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt

Checklist not required