### PR TITLE
Resolve conflict with zoxide

### DIFF
--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -152,7 +152,7 @@ if [[ -d $FZF_PATH/man ]]; then
     manpath+=(":$FZF_PATH/man")
 fi
 
-if _fzf_has z; then
+if _fzf_has z && ! _fzf_has zoxide; then
   unalias z 2> /dev/null
   _fzf_z="_z"
   (( ${+functions[zshz]} )) && { _fzf_z="zshz"; compdef _zshz z; }


### PR DESCRIPTION
Since the zoxide init script (`zoxide init zsh`) alias `z` to `__zoxide_z`, but this plugin unset it. 
If zoxide is detected, don't touch the alias of `z`.