### PR TITLE
Added ability to change color scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,18 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Contents](#contents)
-- [Installing](#installing)
-  - [Zgenom](#zgenom)
-  - [Antigen](#antigen)
-  - [Oh-My-Zsh](#oh-my-zsh)
-  - [Without using a framework](#without-using-a-framework)
-  - [(optional) Install recommended tools](#optional-install-recommended-tools)
-- [Customization](#customization)
-  - [A note on `lessfilter-fzf`](#a-note-on-lessfilter-fzf)
-- [Other FZF resources](#other-fzf-resources)
+- [fzf-zsh-plugin](#fzf-zsh-plugin)
+  - [Table of Contents](#table-of-contents)
+  - [Contents](#contents)
+  - [Installing](#installing)
+    - [Zgenom](#zgenom)
+    - [Antigen](#antigen)
+    - [Oh-My-Zsh](#oh-my-zsh)
+    - [Without using a framework](#without-using-a-framework)
+    - [(optional) Install recommended tools](#optional-install-recommended-tools)
+  - [Customization](#customization)
+    - [A note on `lessfilter-fzf`](#a-note-on-lessfilter-fzf)
+  - [Other FZF resources](#other-fzf-resources)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -105,9 +107,10 @@ You can customize a few features by exporting the following environment variable
 
 | Export variable                    | Description                                                                                                                                                                                                                                                                                  |
 | ---------------------------------- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `export FZF_PREVIEW_ADVANCED=true` | Use `less` viewer with a pre-processor to display improved previews for a wide range of files (requires you to install at least `exa`, `bat`, `chafa`, `exiftool`; and very recommended `lesspipe.sh` and the tools it uses underneath: `mdcat`, `in2csv`,...). _This is an opt-in feature._ |
-| `export FZF_PREVIEW_WINDOW=''`     | Set any value supported by `fzf --preview-window` option, e.g. `right:65%:nohidden` will show the preview by default.                                                                                                                                                                        |
-| `export FZF_PATH=''`               | Path to install fzf binary and script, e.g. `${HOME}/.config/fzf`.                                                                            |
+| `FZF_PREVIEW_ADVANCED` | Use `less` viewer with a pre-processor to display improved previews for a wide range of files (requires you to install at least `exa`, `bat`, `chafa`, `exiftool`; and very recommended `lesspipe.sh` and the tools it uses underneath: `mdcat`, `in2csv`,...). _This is an opt-in feature._ |
+| `FZF_PREVIEW_WINDOW`     | Set any value supported by `fzf --preview-window` option, e.g. `right:65%:nohidden` will show the preview by default.                                                                                                                                                                        |
+| `FZF_PATH`               | Path to install fzf binary and script, e.g. `${HOME}/.config/fzf`.                                                                            |
+| `FZF_COLOR_SCHEME`       | Color scheme for fzf, e.g. `--color='hl:148,hl+:154,pointer:032,marker:010,bg+:237,gutter:008'`                                                                            |
 
 ### A note on `lessfilter-fzf`
 

--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -106,6 +106,7 @@ _fzf_preview() {
 }
 
 # Don't step on user's defined variables. Export to potentially leverage them by other scripts.
+[[ -z "$FZF_COLOR_SCHEME" ]]   && export FZF_COLOR_SCHEME="--color='hl:148,hl+:154,pointer:032,marker:010,bg+:237,gutter:008'"
 [[ -z "$FZF_PREVIEW" ]]        && export FZF_PREVIEW="$(_fzf_preview)"
 [[ -z "$FZF_PREVIEW_WINDOW" ]] && export FZF_PREVIEW_WINDOW=':hidden'
 if [[ -z "$FZF_DEFAULT_OPTS" ]]; then
@@ -116,7 +117,7 @@ if [[ -z "$FZF_DEFAULT_OPTS" ]]; then
     "--multi"
     "--preview='${FZF_PREVIEW}'"
     "--preview-window='${FZF_PREVIEW_WINDOW}'"
-    "--color='hl:148,hl+:154,pointer:032,marker:010,bg+:237,gutter:008'"
+    "$FZF_COLOR_SCHEME"
     "--prompt='∼ '"
     "--pointer='▶'"
     "--marker='✓'"


### PR DESCRIPTION
Enables users to change FZF color scheme

# Description

Adds a `FZF_COLOR_SCHEME` variable in main plugin file with default value.

Closes #91 

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
