### PR TITLE
Replace exa by eza as exa is unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The scripts in this collection don't actually require you to be using ZSH as you
 ### (optional) Install recommended tools
 
 Optionally, to make the most out of `fzf` preview (`?` toggle), install the following tools and enable the advanced preview (see [Customization](#customization) section):
-- `exa` - improved file/directory listing,
+- `eza` - improved file/directory listing,
 - `bat` - a `cat` clone with syntax highlighting and Git integration,
 - `chafa` - show images (the image can look better or worse depending on the terminal app you use),
 - `exiftool` - also show image metadata,
@@ -105,7 +105,7 @@ You can customize a few features by exporting the following environment variable
 
 | Export variable                    | Description                                                                                                                                                                                                                                                                                  |
 | ---------------------------------- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `FZF_PREVIEW_ADVANCED` | Use `less` viewer with a pre-processor to display improved previews for a wide range of files (requires you to install at least `exa`, `bat`, `chafa`, `exiftool`; and very recommended `lesspipe.sh` and the tools it uses underneath: `mdcat`, `in2csv`,...). _This is an opt-in feature._ |
+| `FZF_PREVIEW_ADVANCED` | Use `less` viewer with a pre-processor to display improved previews for a wide range of files (requires you to install at least `eza`, `bat`, `chafa`, `exiftool`; and very recommended `lesspipe.sh` and the tools it uses underneath: `mdcat`, `in2csv`,...). _This is an opt-in feature._ |
 | `FZF_PREVIEW_WINDOW`     | Set any value supported by `fzf --preview-window` option, e.g. `right:65%:nohidden` will show the preview by default.                                                                                                                                                                        |
 | `FZF_PATH`               | Path to install fzf binary and script, e.g. `${HOME}/.config/fzf`.                                                                            |
 | `FZF_COLOR_SCHEME`       | Color scheme for fzf, e.g. `--color='hl:148,hl+:154,pointer:032,marker:010,bg+:237,gutter:008'`                                                                            |

--- a/bin/lessfilter-fzf
+++ b/bin/lessfilter-fzf
@@ -15,7 +15,7 @@
 #   lessfilter-fzf > lesspipe.sh > lessfilter
 #
 # Required tools:
-#   - exa
+#   - eza
 #   - bat
 #   - chafa, exiftool
 #   - lesspipe.sh (recommended)
@@ -34,13 +34,13 @@ category=${mime%%/*}
 # shellcheck disable=SC2034 # left for completion
 kind=${mime##*/}
 
-if [ -d "$1" ] && has_cmd exa; then
-  exa --git --header --long --color=always --icons "$1"
+if [ -d "$1" ] && has_cmd eza; then
+  eza --git --header --long --color=always --icons "$1"
 elif [ "$category" = image ] && has_cmd chafa && has_cmd exiftool; then
   chafa "$1"
   exiftool "$1"
 elif has_cmd lesspipe.sh; then
-  # At the time of writing, `lesspipe.sh` does not use `exa` and `chafa`, it just uses `ls` and `exiftool`. It
+  # At the time of writing, `lesspipe.sh` does not use `eza` and `chafa`, it just uses `ls` and `exiftool`. It
   # will ultimately rely on `less` as a sane fallback.
   lesspipe.sh "$1" 2>/dev/null
 elif [ "$category" = text ] && has_cmd bat; then  # <-- give priority to lesspipe.sh if available


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Replace `exa` by `eza` as exa is unmaintained. The new repository is https://github.com/eza-community/eza

<!--- Describe your changes in detail -->

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
