### PR TITLE
Fix "fzf-zsh-plugin.plugin.zsh…(anon):50: parse error: condition expe…

### DIFF
--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -47,7 +47,7 @@ fi
 unset xdg_path
 
 # Install fzf into ~ if it hasn't already been installed.
-if [[ ! _fzf_has fzf ]]; then
+if ! _fzf_has fzf; then
   if [[ ! -d $FZF_PATH ]]; then
     git clone --depth 1 https://github.com/junegunn/fzf.git $FZF_PATH
     $FZF_PATH/install --bin


### PR DESCRIPTION
Recent change introduced a bug causing:
fzf-zsh-plugin.plugin.zsh:50: parse error: condition expected: _fzf_has

# Description

According to usages in the rest of the repository, proper syntax is as proposed in CL

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [X] All new and existing tests pass.
- [X] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [X] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [X] Scripts are marked executable
- [X] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [X] I have confirmed that the link(s) in my PR are valid.
- [X] I have read the **CONTRIBUTING** document.

# License Acceptance

- [X] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
