### PR TITLE
Don't assume `bat` is installed

### DIFF
--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -102,7 +102,16 @@ fi
 #   - An advanced preview using a `less` preprocessor, capable of showing a wide range of formats, incl. images, dirs,
 #     CSVs, and other binary files (depending on available tooling).
 _fzf_preview() {
-  foolproofPreview='([[ -f {} ]] && (bat --style=numbers --color=always {} || cat {})) || ([[ -d {} ]] && (tree -C {} | less)) || echo {} 2>/dev/null | head -n 200'
+  _fzf_preview_pager='cat'
+  foolproofPreview='cat {}'
+  if _fzf_has bat; then
+    _fzf_preview_pager='bat'
+    foolproofPreview='([[ -f {} ]] && (bat --style=numbers --color=always {} || cat {})) || ([[ -d {} ]] && (tree -C {} | less)) || echo {} 2>/dev/null | head -n 200'
+  fi
+  if _fzf_has batcat; then
+    _fzf_preview_pager='batcat'
+    foolproofPreview='([[ -f {} ]] && (batcat --style=numbers --color=always {} || cat {})) || ([[ -d {} ]] && (tree -C {} | less)) || echo {} 2>/dev/null | head -n 200'
+  fi
   local preview
   [[ "$FZF_PREVIEW_ADVANCED" == true ]] \
     && preview="lessfilter-fzf {}" \


### PR DESCRIPTION
# Description
- Don't assume `bat` is installed for use in previews.
- If it is installed, don't assume is installed as `bat` - it might be installed as `batcat`.

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
