### PR TITLE
Check for `jq` and `fzf` in `pr-list` script

### DIFF
--- a/bin/pr-list
+++ b/bin/pr-list
@@ -25,8 +25,16 @@ function has() {
   which "$@" > /dev/null 2>&1
 }
 
-if has gh; then
-  gh api --paginate 'repos/:owner/:repo/pulls?state=open' | jq -r '.[] | [.number, .user.login, .title] | @tsv' | fzf
-else
+if ! has gh; then
   fail "Cannot find 'gh' in your PATH"
 fi
+
+if ! has jq; then
+  fail "Cannot find 'jq' in your PATH"
+fi
+
+if ! has fzf; then
+  fail "Cannot find 'fzf' in your PATH"
+fi
+
+gh api --paginate 'repos/:owner/:repo/pulls?state=open' | jq -r '.[] | [.number, .user.login, .title] | @tsv' | fzf


### PR DESCRIPTION
# Description

Other scripts check for `fzf`:
- https://github.com/unixorn/fzf-zsh-plugin/blob/671291a0dba1971d5c87a0cdc809711a9b7636fa/bin/fzf-git-checkout#L28-L30
- https://github.com/unixorn/fzf-zsh-plugin/blob/671291a0dba1971d5c87a0cdc809711a9b7636fa/bin/fzf-browse-pods#L41
- https://github.com/unixorn/fzf-zsh-plugin/blob/671291a0dba1971d5c87a0cdc809711a9b7636fa/bin/fzf-vscode#L44-L46

But, this one was not checking `fzf` and `jq`, which is rather unique for this script. So, I've updated the deps list.

<!--- Provide a general summary of your changes in the Title above -->



<!--- Describe your changes in detail -->

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [ ] All new and existing tests pass.
- [ ] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have confirmed that the link(s) in my PR are valid.
- [ ] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
