### PR TITLE
`bin/d-attach` defines function `da` but calls function `dattach`

### DIFF
--- a/bin/d-attach
+++ b/bin/d-attach
@@ -16,8 +16,8 @@ function debug() {
 }
 
 function fail() {
-  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
-  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+  printf '%s\n' "$1" >&2 ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"          ## Return a code specified by $2 or 1 by default.
 }
 
 function has() {
@@ -33,7 +33,7 @@ function da() {
 }
 
 if has docker; then
-  dattach "$@"
+  da "$@"
 else
   "Cannot find docker in $PATH"
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

The script `bin/d-attach` defines a function named `da`, but calls function `dattach`, which is not defined. Running the script results in an error message:

```
❯ d-attach                                                      
/Users/jxb2016/.zgenom/sources/unixorn/fzf-zsh-plugin/___/bin/d-attach: line 36: dattach: command not found
```

This update changes the script so that it calls `da`.

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
