### PR TITLE
d-image-rm: handle multiple tags for same image

### DIFF
--- a/bin/d-image-rm
+++ b/bin/d-image-rm
@@ -16,8 +16,8 @@ function debug() {
 }
 
 function fail() {
-  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
-  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+  printf '%s\n' "$1" >&2 ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"          ## Return a code specified by $2 or 1 by default.
 }
 
 function has() {
@@ -27,7 +27,11 @@ function has() {
 
 # Select a docker image or images to remove
 function drmi() {
-  docker images | sed 1d | fzf -q "$1" --no-sort -m --tac | awk '{ print $3 }' | xargs -r docker rmi
+  # if the image has no tag, use the image id, otherwise use the image name and
+  # tag; allows removing a tag from an image with multiple tags
+  docker images | sed 1d | fzf -q "$1" --no-sort -m --tac |
+    awk '{ print ($2=="<none>")?$3:$1 ":" $2 }' |
+    xargs -r docker rmi
 }
 
 if has docker; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->
When selecting the images to delete, check if the `tag` of an image is the string `<none>`. If it is, then use the image ID,
otherwise, use `repo:tag` for the name of the image to remove.

When an image ID has multiple tags, removing by just the ID will fail.

E.g.:
```
❯ docker image ls | grep ubuntu
docker.artifactory.homedepot.com/ubuntu                                    18.04                d1a528908992   19 months ago   56.7MB
docker.artifactory.homedepot.com/ubuntu                                    18.10                6b562d43ba8f   5 years ago     60.9MB
docker.artifactory.homedepot.com/ubuntu                                    sid                  6b562d43ba8f   5 years ago     60.9MB
```

![image](https://github.com/user-attachments/assets/d734e187-67ac-4085-bee6-75a19bf08ab4)

```
Error response from daemon: conflict: unable to delete 6b562d43ba8f (must be forced) - image is referenced in multiple repositories
```

With this update:
![image](https://github.com/user-attachments/assets/7fbdf744-f226-4911-87ff-bb2b726d8b14)
![image](https://github.com/user-attachments/assets/25a5f302-0864-4bd6-beb4-27524de6ff8b)

Removing images with missing tag and or repo:
![image](https://github.com/user-attachments/assets/41a40e71-aafc-4c50-b86e-8097412555fb)
![image](https://github.com/user-attachments/assets/8954cf6a-9fcf-4556-b0d1-92942958e617)


# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
