### PR TITLE
Update Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Add `antigen bundle unixorn/fzf-zsh-plugin@main` to your `.zshrc`
 
 ### Without using a framework
 
-1. `git clone --depth 1 git@github.com:unixorn/fzf-zsh-plugin.git`, then add its `bin` directory to your `$PATH`.
+1. `git clone --depth 1 https://github.com/unixorn/fzf-zsh-plugin.git`, then add its `bin` directory to your `$PATH`.
 2. Add `source /path/to/repository/checkout/fzf-zsh-plugin.plugin.zsh` to your `.zshrc` file.
 
 The scripts in this collection don't actually require you to be using ZSH as your login shell, they're being distributed as an [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh)-compatible plugin because it's convenient for me.

--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -52,6 +52,7 @@ unset xdg_path
 if ! _fzf_has fzf; then
   if [[ ! -d $FZF_PATH ]]; then
     git clone --depth 1 https://github.com/junegunn/fzf.git $FZF_PATH
+    [ $(which bash) ] >/dev/null || apk add bash
     $FZF_PATH/install --bin
   fi
 fi


### PR DESCRIPTION
### Summary
This pull request includes two commits to improve the installation process.

1. Install bash before FZF installation  
   The first commit addresses the requirement for Bash when installing FZF. Some distributions, such as Alpine, do not include **bash** by default, and the current installation instructions do not specify this dependency.

2. Update installation instructions without using a framework repository link  
   The second commit modifies the installation instructions to accommodate users who may not have an SSH key configured for GitHub, allowing them to use the HTTPS link instead of the `git@github.com` format for cloning.

### Changes
- Added Bash installation step for FZF.
- Updated repository cloning instructions to support HTTPS.

Thank you for considering this pull request!