### PR TITLE
Fix chrome-history command failing due to variable shadowing

### DIFF
--- a/bin/chrome-history
+++ b/bin/chrome-history
@@ -41,7 +41,7 @@ trap cleanup EXIT
 
 # browse Chrome history
 chrome-history() {
-  local cols sep chrome_history open
+  local cols sep
   cols=$(( COLUMNS / 3 ))
   sep='{::}'
 


### PR DESCRIPTION
## Summary

Fix the `chrome-history` command which always fails with "No such file or directory" and "no such table: urls" errors when called. The variables `chrome_history` and `open` are not declared inside of the function.

This function is trying to access the chrome_history and open vars that are in outer scope.

## Problem
  The `chrome-history()` function declared `chrome_history` and `open` as local variables, which
  shadowed the global variables set earlier in the script. This caused the function to use empty
  local variables instead of the properly initialized global ones containing the Chrome history
  file path and system-appropriate open command. This caused this error:
```bash
  $ chrome-history
  cp: : No such file or directory
  Error: in prepare, no such table: urls
```

  ## Solution
  Remove `chrome_history` and `open` from the local variable declaration, allowing the function
  to access the outer variables.

# Checklist

- [x] All new and existing tests pass.
- [x] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
