### PR TITLE
Check if `fzf` was installed by `brew`

### DIFF
--- a/fzf-settings.zsh
+++ b/fzf-settings.zsh
@@ -4,10 +4,32 @@ if [[ ! "$PATH" == *${FZF_PATH}/bin* ]]; then
   export PATH="$PATH:${FZF_PATH}/bin"
 fi
 
+function _fzf_has() {
+  which "$@" > /dev/null 2>&1
+}
+
+if _fzf_has brew; then
+  # If fzf was installed via brew, use the brew paths
+  if [[ -x "$(brew --prefix)/bin/fzf" ]]; then
+    if [[ -f "$(brew --prefix fzf)/shell/completion.zsh" ]]; then
+      source "$(brew --prefix fzf)/shell/completion.zsh" 2> /dev/null
+    fi
+    if [[ -f "$(brew --prefix fzf)/shell/key-bindings.zsh" ]]; then
+      source "$(brew --prefix fzf)/shell/key-bindings.zsh"
+    fi
+  fi
+fi
+
 # Auto-completion
 # ---------------
-[[ $- == *i* ]] && source "${FZF_PATH}/shell/completion.zsh" 2> /dev/null
+if [[ -f "${FZF_PATH}/shell/completion.zsh" ]]; then
+  [[ $- == *i* ]] && source "${FZF_PATH}/shell/completion.zsh" 2> /dev/null
+fi
 
 # Key bindings
 # ------------
-source "${FZF_PATH}/shell/key-bindings.zsh"
+if [[ -f "${FZF_PATH}/shell/key-bindings.zsh" ]]; then
+  source "${FZF_PATH}/shell/key-bindings.zsh"
+fi
+
+unset -f _fzf_has


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

# Description

If fzf was installed by `brew`, the completions and keybindings files are in `$(brew --prefix fzf)/shell`, so source them from there instead of `$FZF_PATH/shell`

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
