### PR TITLE
Fix #125, hopefully

### DIFF
--- a/fzf-settings.zsh
+++ b/fzf-settings.zsh
@@ -31,5 +31,3 @@ fi
 if [[ -f "${FZF_PATH}/shell/key-bindings.zsh" ]]; then
   source "${FZF_PATH}/shell/key-bindings.zsh"
 fi
-
-unset -f _fzf_has

--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Joseph Block <jpb@unixorn.net>
+# Copyright 2020-2025 Joseph Block <jpb@unixorn.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Remove extra `unset -f _fzf_haz`

Fixes #125, hopefully

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [ ] All new and existing tests pass.
- [ ] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
