### PR TITLE
Replace `_fzf_has()`

### DIFF
--- a/fzf-settings.zsh
+++ b/fzf-settings.zsh
@@ -4,11 +4,7 @@ if [[ ! "$PATH" == *${FZF_PATH}/bin* ]]; then
   export PATH="$PATH:${FZF_PATH}/bin"
 fi
 
-function _fzf_has() {
-  which "$@" > /dev/null 2>&1
-}
-
-if _fzf_has brew; then
+if  (( $+commands[brew] )); then
   # If fzf was installed via brew, use the brew paths
   if [[ -x "$(brew --prefix)/bin/fzf" ]]; then
     if [[ -f "$(brew --prefix fzf)/shell/completion.zsh" ]]; then

--- a/fzf-zsh-plugin.plugin.zsh
+++ b/fzf-zsh-plugin.plugin.zsh
@@ -25,10 +25,6 @@ if [[ -d "$FZF_COMPLETIONS_D" ]]; then
 fi
 unset FZF_COMPLETIONS_D
 
-function _fzf_has() {
-  which "$@" > /dev/null 2>&1
-}
-
 function _fzf_debugOut() {
   if [[ -n "$DEBUG" ]]; then
     echo "$@"
@@ -49,7 +45,7 @@ fi
 unset xdg_path
 
 # Install fzf into ~ if it hasn't already been installed.
-if ! _fzf_has fzf; then
+if ! (( $+commands[fzf] )); then
   if [[ ! -d $FZF_PATH ]]; then
     git clone --depth 1 https://github.com/junegunn/fzf.git $FZF_PATH
     $FZF_PATH/install --bin
@@ -75,14 +71,14 @@ if [[ -z "$FZF_DEFAULT_COMMAND" ]]; then
   export FZF_DEFAULT_COMMAND='find . -type f -not \( -path "*/.git/*" -o -path "./node_modules/*" \)'
   export FZF_ALT_C_COMMAND='find . -type d ( -path .git -o -path node_modules ) -prune'
 
-  if _fzf_has rg; then
+  if (( $+commands[rg] )); then
     # rg is faster than find, so use it instead.
     export FZF_DEFAULT_COMMAND='rg --files --hidden --follow --glob "!{.git,node_modules}/**"'
   fi
 
   # If fd command is installed, use it instead of find
-  _fzf_has 'fd' && _fd_cmd="fd"
-  _fzf_has 'fdfind' && _fd_cmd="fdfind"
+   (( $+commands[fd] )) && _fd_cmd="fd"
+   (( $+commands[fdfind] ))  && _fd_cmd="fdfind"
   if [[ -n "$_fd_cmd" ]]; then
     # Show hidden, and exclude .git and the pigsty node_modules files
     export FZF_DEFAULT_COMMAND="$_fd_cmd --hidden --follow --exclude '.git' --exclude 'node_modules'"
@@ -106,11 +102,11 @@ fi
 _fzf_preview() {
   _fzf_preview_pager='cat'
   foolproofPreview='cat {}'
-  if _fzf_has bat; then
+  if (( $+commands[bat] )); then
     _fzf_preview_pager='bat'
     foolproofPreview='([[ -f {} ]] && (bat --style=numbers --color=always {} || cat {})) || ([[ -d {} ]] && (tree -C {} | less)) || echo {} 2>/dev/null | head -n 200'
   fi
-  if _fzf_has batcat; then
+  if (( $+commands[batcat] )); then
     _fzf_preview_pager='batcat'
     foolproofPreview='([[ -f {} ]] && (batcat --style=numbers --color=always {} || cat {})) || ([[ -d {} ]] && (tree -C {} | less)) || echo {} 2>/dev/null | head -n 200'
   fi
@@ -142,14 +138,14 @@ if [[ -z "$FZF_DEFAULT_OPTS" ]]; then
     "--bind 'ctrl-e:execute(vim {+} >/dev/tty)'"
     "--bind 'ctrl-v:execute(code {+})'"
   )
-  if _fzf_has pbcopy; then
+  if (( $+commands[pbcopy] )); then
     # On macOS, make ^Y yank the selection to the system clipboard. On Linux you can alias pbcopy to `xclip -selection clipboard` or corresponding tool.
     fzf_default_opts+=("--bind 'ctrl-y:execute-silent(echo {+} | pbcopy)'")
   fi
   export FZF_DEFAULT_OPTS=$(printf '%s\n' "${fzf_default_opts[@]}")
 fi
 
-if _fzf_has tree; then
+if (( $+commands[tree] )); then
   function fzf-change-directory() {
     local directory=$(
       fd --type d | \
@@ -169,7 +165,7 @@ if [[ -d $FZF_PATH/man ]]; then
     manpath+=(":$FZF_PATH/man")
 fi
 
-if _fzf_has z && ! _fzf_has zoxide; then
+if (( $+commands[z] )) && !  (( $+commands[zoxide] )); then
   unalias z 2> /dev/null
   _fzf_z="_z"
   (( ${+functions[zshz]} )) && { _fzf_z="zshz"; compdef _zshz z; }
@@ -190,8 +186,8 @@ function cdf() {
   file=$(fzf +m -q "$1") && dir=$(dirname "$file") && cd "$dir"
 }
 
-if _fzf_has pbcopy; then
-  if _fzf_has ghead; then
+if (( $+commands[pbcopy] )); then
+  if (( $+commands[ghead] )); then
     function falias {
         # Search alias by key or values
         local out
@@ -203,5 +199,4 @@ fi
 
 # Cleanup internal functions
 unset -f _fzf_debugOut
-unset -f _fzf_has
 unset -f _fzf_preview


### PR DESCRIPTION
# Description

`_fzf_has()` is getting unset when it shouldn't be. Replace `_fzf_has()` with `(( $+commands[commandname] ))` to hopefully fix #125

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Rather than adding functions to `fzf-zsh-plugin.zsh`, I have created standalone scripts in bin so they can be used by non-ZSH users too.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
